### PR TITLE
iscsi: Adapt package names for SUSE installations

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -797,8 +797,9 @@ class Iscsi(object):
     def create_iSCSI(params, root_dir=data_dir.get_tmp_dir()):
         iscsi_instance = None
         ubuntu = distro.detect().name == "Ubuntu"
+        suse = distro.detect().name == "SuSE"
         # check and install iscsi initiator packages
-        if ubuntu:
+        if ubuntu or suse:
             iscsi_package = ["open-iscsi"]
         else:
             iscsi_package = ["iscsi-initiator-utils"]
@@ -813,7 +814,7 @@ class Iscsi(object):
                 "target-utils or tgt package"
             )
             # try with scsi target utils if targetcli is not available
-            if ubuntu:
+            if ubuntu or suse:
                 iscsi_package = ["tgt"]
             else:
                 iscsi_package = ["scsi-target-utils"]


### PR DESCRIPTION
When attempting to install iSCSI initiator and target packages on SUSE, it was observed that the test suite was failing due to incorrect package names.

Specifically, SUSE utilizes open-iscsi for the iSCSI initiator, as opposed to iscsi-initiator-utils. Similarly, the SCSI target utilities on SUSE are provided by the tgt package, not scsi-target-utils.

This commit introduces a conditional check for SUSE distributions to ensure the correct iSCSI initiator (open-iscsi) and target (tgt) packages are selected and installed, thereby resolving installation failures on SUSE systems.

NOTE: This PR has already been merged in upstream.
upstream PR: avocado-framework#4136

Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>