### PR TITLE
virttest: add ipv6 portal check for iscsi

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -726,16 +726,12 @@ class IscsiLIO(_IscsiComm):
 
             check_portal = "targetcli /iscsi/%s/tpg1/portals ls" % self.target
             portal_info = process.run(check_portal).stdout_text
-            if "[::0]:3260" in portal_info:
-                # Remove the IPv6 portal
-                remove_portal_cmd = "targetcli /iscsi/%s/tpg1/portals/ delete ::0 ip_port=3260" % (self.target)
-                output = process.run(remove_portal_cmd).stdout_text
-                if "Deleted network portal" not in output:
-                    raise exceptions.TestFail("Failed to delete portal. (%s)" % output)
-            if "0.0.0.0:3260" not in portal_info:
+            # Check for both IPv4 (0.0.0.0:3260) and IPv6 ([::]:3260 or [::0]:3260) default portals
+            if "0.0.0.0:3260" not in portal_info and "[::]:3260" not in portal_info and "[::0]:3260" not in portal_info:
                 # Create portal
-                # 0.0.0.0 means binding to INADDR_ANY
-                # and using default IP port 3260
+                # 0.0.0.0 means binding to INADDR_ANY (IPv4)
+                # [::] or [::0] means binding to in6addr_any (IPv6)
+                # using default IP port 3260
                 portal_cmd = "targetcli /iscsi/%s/tpg1/portals/ create %s" % (
                     self.target,
                     "0.0.0.0",

--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -727,7 +727,7 @@ class IscsiLIO(_IscsiComm):
             check_portal = "targetcli /iscsi/%s/tpg1/portals ls" % self.target
             portal_info = process.run(check_portal).stdout_text
             # Check for both IPv4 (0.0.0.0:3260) and IPv6 ([::]:3260 or [::0]:3260) default portals
-            if "0.0.0.0:3260" not in portal_info and "[::]:3260" not in portal_info and "[::0]:3260" not in portal_info:
+            if not any(portal in portal_info for portal in ("0.0.0.0:3260", "[::]:3260", "[::0]:3260")):
                 # Create portal
                 # 0.0.0.0 means binding to INADDR_ANY (IPv4)
                 # [::] or [::0] means binding to in6addr_any (IPv6)


### PR DESCRIPTION
Fix how portal existence is checked for iscsi to take ipv6 portals into account