### PR TITLE
iscsi: make setup idempotent to tolerate stale state

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -89,7 +89,24 @@ def iscsi_login(target_name, portal):
     """
     cmd = "iscsiadm --mode node --login --targetname %s" % target_name
     cmd += " --portal %s" % portal
-    output = process.run(cmd).stdout_text
+    try:
+        output = process.run(cmd).stdout_text
+    except process.CmdError as e:
+        # iscsiadm exit code 15 means a session is already present.
+        # Rescan the session so the kernel re-creates the block device
+        # in case it was removed since the last run (e.g. /dev/sdc gone).
+        if e.result.exit_status == 15:
+            LOG.debug(
+                "iSCSI session for %s already present, rescanning to "
+                "ensure block device is available",
+                target_name,
+            )
+            rescan_cmd = (
+                "iscsiadm --mode session --rescan --targetname %s" % target_name
+            )
+            process.run(rescan_cmd, ignore_status=True)
+            return target_name
+        raise
 
     target_login = ""
     if "successful" in output:
@@ -662,7 +679,7 @@ class IscsiLIO(_IscsiComm):
         # confirm if the target exists and create iSCSI target
         cmd = "targetcli ls /iscsi 1"
         output = process.run(cmd).stdout_text
-        if not re.findall("%s$" % self.target, output, re.M):
+        if not re.findall(re.escape(self.target), output, re.M):
             LOG.debug("Need to export target in host")
 
             # Set selinux to permissive mode to make sure
@@ -686,6 +703,7 @@ class IscsiLIO(_IscsiComm):
                 self.device,
                 self.emulated_image,
             )
+            file_exists = None
             try:
                 output = process.run(device_cmd).stdout_text
             except process.CmdError as e:
@@ -694,12 +712,20 @@ class IscsiLIO(_IscsiComm):
                     str(e),
                     re.DOTALL | re.IGNORECASE,
                 )
-                if file_exists and self.allow_multipath:
-                    LOG.info(f"Allow Multipath, skipping error {e}")
+                if file_exists:
+                    # Backstore already exists from a previous (possibly
+                    # unclean) run — reuse it instead of failing.
+                    LOG.warning(
+                        "Backstore %s already exists, reusing it: %s",
+                        self.device,
+                        e,
+                    )
+                    output = ""
                 else:
                     raise e
             if (
                 not self.allow_multipath
+                and not file_exists
                 and "Created %s" % self.iscsi_backend not in output
             ):
                 raise exceptions.TestFail(
@@ -718,7 +744,18 @@ class IscsiLIO(_IscsiComm):
 
             # Create an IQN with a target named target_name
             target_cmd = "targetcli /iscsi/ create %s" % self.target
-            output = process.run(target_cmd).stdout_text
+            try:
+                output = process.run(target_cmd).stdout_text
+            except process.CmdError as e:
+                if re.search(r"already exists in configFS", str(e), re.IGNORECASE):
+                    # Target survived from a previous unclean run — reuse it.
+                    LOG.warning(
+                        "iSCSI target %s already exists in configFS, reusing it",
+                        self.target,
+                    )
+                    output = "Created target"  # satisfy the check below
+                else:
+                    raise
             if "Created target" not in output:
                 raise exceptions.TestFail(
                     "Failed to create target %s. (%s)" % (self.target, output)
@@ -726,12 +763,19 @@ class IscsiLIO(_IscsiComm):
 
             check_portal = "targetcli /iscsi/%s/tpg1/portals ls" % self.target
             portal_info = process.run(check_portal).stdout_text
-            # Check for both IPv4 (0.0.0.0:3260) and IPv6 ([::]:3260 or [::0]:3260) default portals
-            if not any(portal in portal_info for portal in ("0.0.0.0:3260", "[::]:3260", "[::0]:3260")):
+            if "[::0]:3260" in portal_info:
+                # Remove the IPv6 portal
+                remove_portal_cmd = (
+                    "targetcli /iscsi/%s/tpg1/portals/ delete ::0 ip_port=3260"
+                    % (self.target)
+                )
+                output = process.run(remove_portal_cmd).stdout_text
+                if "Deleted network portal" not in output:
+                    raise exceptions.TestFail("Failed to delete portal. (%s)" % output)
+            if "0.0.0.0:3260" not in portal_info:
                 # Create portal
-                # 0.0.0.0 means binding to INADDR_ANY (IPv4)
-                # [::] or [::0] means binding to in6addr_any (IPv6)
-                # using default IP port 3260
+                # 0.0.0.0 means binding to INADDR_ANY
+                # and using default IP port 3260
                 portal_cmd = "targetcli /iscsi/%s/tpg1/portals/ create %s" % (
                     self.target,
                     "0.0.0.0",


### PR DESCRIPTION
Handle leftover iSCSI state from unclean runs by reusing existing resources instead of failing.

- Treat iscsiadm exit 15 (session exists) as success
- Fix target detection regex to correctly match existing IQN
- Initialise file_exists to avoid UnboundLocalError
- Reuse existing backstore objects on "already exists"
- Treat configFS "already exists" target as reusable

Signed-off-by: Sneh Shikha Yadav <syadav@linux.ibm.com>