### PR TITLE
libvirt : wait for udev after login to avoid /dev/sdX race

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -596,6 +596,7 @@ def setup_or_cleanup_iscsi(
             # The new block device might not become immediately available
             # so wait for it both for iscsiadm as well as the filesystem
             # to have finished the setup
+            process.run("udevadm settle", ignore_status=True)
             iscsi_device = utils_misc.wait_for(
                 _iscsi.get_device_name, 5, 0, 1, "Searching iscsi device name."
             )


### PR DESCRIPTION
iscsiadm may report an attached disk before udev creates the
corresponding /dev node, causing early userspace access (e.g.
parted/mkfs) to fail with ENOENT.

Call `udevadm settle` after login to ensure device nodes are ready.

Signed-off-by: Sneh Shikha Yadav <syadav@linux.ibm.com>