### PR TITLE
Adding cfg file to enable 16.1 for naming convention in avocado!

### DIFF
--- a/virttest/shared/cfg/guest-os/Linux/SLES/16.1.ppc64le.cfg
+++ b/virttest/shared/cfg/guest-os/Linux/SLES/16.1.ppc64le.cfg
@@ -1,0 +1,7 @@
+- 16.1.ppc64le:
+    image_name = images/sles-16.1-ppc64le
+    vm_arch_name = ppc64le
+    #shell_prompt = "^.*:~[\#\$]\s*$"
+    shell_prompt = ".*[#\$] "
+    os_variant = sles16
+


### PR DESCRIPTION
Enabled this for naming convention of guest as sles-16.1-ppc64le.qcow2 and run it like :
python3 avocado-setup.py --run-suite guest_cpu --guest-os SLES.16.1.ppc64le --only-filter 'virtio_scsi virtio_net qcow2' --no-download
Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>