### PR TITLE
Adding fedora common cfg file for naming convention!

### DIFF
--- a/virttest/shared/cfg/guest-os/Linux/Fedora/43.cfg
+++ b/virttest/shared/cfg/guest-os/Linux/Fedora/43.cfg
@@ -1,0 +1,6 @@
+- 43:
+    variants:
+        - ppc64le:
+            vm_arch_name = ppc64le
+    image_name = images/fedora-43-ppc64le
+    os_variant = fedora40


### PR DESCRIPTION
After adding this we can run all our fedora tests with the following qcow2 as naming convention with fedora-43-ppc64le.qcow2 and python command can be run as:

python3 avocado-setup.py --run-suite guest_cpu --guest-os Fedora.43.ppc64le --only-filter 'virtio_scsi virtio_net qcow2' --no-download

Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>