### PR TITLE
Adding cfg for ubuntu proper naming convention!

### DIFF
--- a/virttest/shared/cfg/guest-os/Linux/Ubuntu/25.10.ppc64le.cfg
+++ b/virttest/shared/cfg/guest-os/Linux/Ubuntu/25.10.ppc64le.cfg
@@ -1,0 +1,6 @@
+- 25.10.ppc64le:
+    image_name += -25.10-ppc64le
+    shell_prompt = "^.*:~[\#\$]\s*$"
+    vm_arch_name = ppc64le
+    os_variant = ubuntu25.10
+


### PR DESCRIPTION
After adding this we can run all our ubuntu tests with the following qcow2 as naming convention with ubuntu-25.10-ppc64le.qcow2 and python command can be run as:

python3 avocado-setup.py --run-suite guest_cpu --guest-os Ubuntu.25.10.ppc64le --only-filter 'virtio_scsi virtio_net qcow2' --no-download

Signed-off-by: Anushree-Mathur anushree.mathur@linux.ibm.com