### PR TITLE
Adding rhel cfg for proper naming convention!

### DIFF
--- a/virttest/shared/cfg/guest-os/Linux/RHEL/10/10.devel.cfg
+++ b/virttest/shared/cfg/guest-os/Linux/RHEL/10/10.devel.cfg
@@ -1,0 +1,6 @@
+- devel:
+    variants:
+        - ppc64le:
+            vm_arch_name = ppc64le
+    image_name = images/rhel-10-ppc64le
+    os_variant = rhel9.0


### PR DESCRIPTION
After adding this we can run all our ubuntu tests with the following qcow2 as naming convention with rhel-10-ppc64le.qcow2 and python command can be run as:

python3 avocado-setup.py --run-suite guest_cpu --guest-os RHEL.10.devel.ppc64le --only-filter 'virtio_scsi virtio_net qcow2' --no-download

Signed-off-by: Anushree-Mathur anushree.mathur@linux.ibm.com